### PR TITLE
Make (almost) every addon work with it

### DIFF
--- a/lua/autorun/client/cl_cfc_optional_addon_ui.lua
+++ b/lua/autorun/client/cl_cfc_optional_addon_ui.lua
@@ -8,7 +8,7 @@ allowedAddons["1621144907"] = true -- Prop info hud https://steamcommunity.com/s
 allowedAddons["1452363997"] = true -- compass https://steamcommunity.com/sharedfiles/filedetails/?id=1452363997
 allowedAddons["1805621283"] = true -- dynamic 3d hud https://steamcommunity.com/sharedfiles/filedetails/?id=1805621283
 
-__CFCLoaderLocalPath = ""
+local __CFCLoaderLocalPath = ""
 
 local function normalizePath(path)
     local parts = {}
@@ -39,7 +39,7 @@ local newInclude = function( fileName )
         fileName = normalizePath( string.format( "%s/%s", addonDirectory, fileName ) )
     end
     -- print( __CFCLoaderLocalPath )
-    local code = file.Read( fileName, "WORKSHOP" )
+    local code = file.Read( "lua/" .. fileName, "WORKSHOP" ) -- Try to include absolute path
     if code then
         print( "[CL ADDON LOADER] filename, including: ", fileName )
         local oldPath = __CFCLoaderLocalPath
@@ -49,7 +49,7 @@ local newInclude = function( fileName )
         return
     end
     fileName = __CFCLoaderLocalPath .. fileName
-    code = file.Read( fileName, "WORKSHOP" )
+    code = file.Read( fileName, "WORKSHOP" ) -- Try to include local path
     if code then
         print( "[CL ADDON LOADER] filename, including: ", fileName )
         local oldPath = __CFCLoaderLocalPath

--- a/lua/autorun/client/cl_cfc_optional_addon_ui.lua
+++ b/lua/autorun/client/cl_cfc_optional_addon_ui.lua
@@ -8,6 +8,71 @@ allowedAddons["1621144907"] = true -- Prop info hud https://steamcommunity.com/s
 allowedAddons["1452363997"] = true -- compass https://steamcommunity.com/sharedfiles/filedetails/?id=1452363997
 allowedAddons["1805621283"] = true -- dynamic 3d hud https://steamcommunity.com/sharedfiles/filedetails/?id=1805621283
 
+__CFCLoaderLocalPath = ""
+
+local function normalizePath(path)
+    local parts = {}
+    for part in string.gmatch(path, "[^/]+") do
+        if part == ".." then
+            table.remove(parts)
+        elseif part ~= "." then
+            table.insert(parts, part)
+        end
+    end
+    return table.concat(parts, "/")
+end
+
+local function removeLayer( fileName )
+    for i = #fileName - 1, 1, -1 do
+        if fileName[i] == "/" or fileName[i] == "\\" then return string.sub( fileName, 1, i ) end
+    end
+end
+
+local oldInclude = oldInclude or include
+include = function( fileName )
+    -- print( "including " .. fileName )
+    local info = debug.getinfo( 2 )
+    if string.StartsWith( info.short_src, "CFC_ClAddonLoader" ) then
+        -- TODO: Make sure that the bit below actually handles .. correctly
+        local isTraversing = fileName:find( "%.%." ) ~= nil
+        if isTraversing then
+            local addonDirectory = debug.getinfo( 2, "S" ).source:sub( 2 )
+            addonDirectory = addonDirectory:gsub( "[^/]+/", "", 3 )
+            addonDirectory = addonDirectory:gsub( "/[^/]+$", "" )
+            fileName = normalizePath( string.format( "%s/%s", addonDirectory, fileName ) )
+        end
+        -- print( __CFCLoaderLocalPath )
+        local code = file.Read( fileName, "WORKSHOP" )
+        if code then
+            print( "[CL ADDON LOADER] filename, including: ", fileName )
+            local oldPath = __CFCLoaderLocalPath
+            __CFCLoaderLocalPath = removeLayer( fileName )
+            RunString( code, "CFC_ClAddonLoader_" .. fileName )
+            __CFCLoaderLocalPath = oldPath
+            return
+        end
+        fileName = __CFCLoaderLocalPath .. fileName
+        code = file.Read( fileName, "WORKSHOP" )
+        if code then
+            print( "[CL ADDON LOADER] filename, including: ", fileName )
+            local oldPath = __CFCLoaderLocalPath
+            __CFCLoaderLocalPath = removeLayer( fileName )
+            RunString( code, "CFC_ClAddonLoader_" .. fileName )
+            __CFCLoaderLocalPath = oldPath
+            return
+        end
+        print( "[CL ADDON LOADER] Failed including " .. fileName )
+    else
+        oldInclude( fileName )
+    end
+end
+
+local function validFile( filename )
+    if !string.StartsWith( filename, "lua/autorun/" ) then return false end
+    local paths = string.Split( filename, "/" )
+    return paths[ 3 ] != "client" and !paths[ 4 ] or paths[ 3 ] == "client" and !paths[ 5 ] -- Make sure that files outside of /autorun/ and /autorun/client/ don't get executed (including subdirectories!)
+end
+
 local function mountAddon( id )
     steamworks.DownloadUGC( id, function( name )
         local success, files = game.MountGMA( name )
@@ -16,11 +81,10 @@ local function mountAddon( id )
         end
 
         for _, filename in pairs( files ) do
-            local isAutorun = string.match( filename, "^lua/autorun/.*%.lua" )
-            local isServer = string.StartWith( filename, "lua/autorun/server" )
-            if isAutorun and not isServer then
+            if validFile( filename ) then
                 print( "[CL ADDON LOADER] filename, running: ", filename )
 
+                __CFCLoaderLocalPath = "lua/autorun/"
                 local code = file.Read( filename, "WORKSHOP" )
                 RunString( code, "CFC_ClAddonLoader_" .. id .. ".lua" )
             end
@@ -105,7 +169,7 @@ hook.Add( "AddToolMenuCategories", "CFC_OptionalAddons_AddMenuCategory", functio
 end )
 
 hook.Add( "PopulateToolMenu", "CFC_OptionalAddons_CreateOptionsMenu", function()
-    spawnmenu.AddToolMenuOption( "Options", "OptionalAddons", "optional_addons", "OptionalAddons", "", "", function( panel )
+    spawnmenu.AddToolMenuOption( "Options", "OptionalAddons", "optional_addons", "Optional Addons", "", "", function( panel )
         populatePanel( panel )
     end )
 end )


### PR DESCRIPTION
ohhh boy this was a fun one
how it works:
1. hijacks include()
2. checks if the source is "CFC_ClAddonLoader" using debug.getinfo()
3. if is, then run the string
4. throughout all of this keeps track of local path
todo:
1. test all edgecases
2. make sure that line 41-47 actually handles .. correctly
tested addons:
https://steamcommunity.com/sharedfiles/filedetails/?id=2954934766
https://steamcommunity.com/sharedfiles/filedetails/?id=2972603323
https://steamcommunity.com/sharedfiles/filedetails/?id=1705992410
things that won't work:
1. addons with timed includes (will fail because include gets detoured only when loading)
2. addons that rely on any sorts of initialize hooks (probably can be fixed by temporarily detouring hook.Add as well)
3. other stuff probably
if you want to make it actually work with 100% everything you should probably do something like a custom file environment like midgame workshop hotloader. is it worth the effort tho?